### PR TITLE
feat: Implement internal messaging and notification module

### DIFF
--- a/src/main/java/co/edu/udes/backend/controllers/MessageController.java
+++ b/src/main/java/co/edu/udes/backend/controllers/MessageController.java
@@ -2,7 +2,6 @@ package co.edu.udes.backend.controllers;
 
 import co.edu.udes.backend.dto.MessageDTO;
 import co.edu.udes.backend.mappers.MessageMapper;
-import co.edu.udes.backend.models.Message;
 import co.edu.udes.backend.services.MessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,25 +37,22 @@ public class MessageController {
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@RequestBody List<MessageDTO> dtos){
-        try{
-            System.out.println(dtos);
-            List<Message> entities = messageMapper.toEntityList(dtos);
-            return ResponseEntity.ok(messageService.createMultiple(entities));
-        }catch (Exception e){
-            return ResponseEntity.badRequest().body("Please check the data you are sending" + e.getMessage());
+    public ResponseEntity<MessageDTO> create(@RequestBody MessageDTO messageDTO) {
+        try {
+            MessageDTO createdMessage = messageService.create(messageDTO);
+            return new ResponseEntity<>(createdMessage, HttpStatus.CREATED);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(null); // O un mensaje de error más específico
         }
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<?> update(@PathVariable Long id, @RequestBody MessageDTO dto) {
-        try{
-            Message message = messageMapper.toEntity(dto);
-            return ResponseEntity.ok(messageService.update(id, message));
-        }catch (RuntimeException e){
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-        }catch(Exception e){
-            return ResponseEntity.badRequest().body("Please check the data you are sending");
+    public ResponseEntity<MessageDTO> update(@PathVariable Long id, @RequestBody MessageDTO messageDTO) {
+        try {
+            MessageDTO updatedMessage = messageService.update(id, messageDTO);
+            return ResponseEntity.ok(updatedMessage);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null); // O badRequest si la data es inválida
         }
     }
 
@@ -67,6 +63,46 @@ public class MessageController {
             return ResponseEntity.noContent().build();
         }catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    // modulos
+
+    // Endpoint para obtener los mensajes recibidos por un usuario
+    /*
+     * Este endpoint permite obtener todos los mensajes que han sido enviados
+     * a un usuario específico, identificado por su ID.
+     *
+     * @param userId El ID del usuario del cual se quieren obtener los mensajes recibidos.
+     * @return ResponseEntity con una lista de MessageDTO si el usuario existe,
+     * o un estado NOT_FOUND (404) si el usuario no se encuentra.
+     */
+    @GetMapping("/received/user/{userId}")
+    public ResponseEntity<List<MessageDTO>> getReceivedMessagesByUser(@PathVariable Long userId) {
+        try {
+            List<MessageDTO> receivedMessages = messageService.getReceivedByUserId(userId);
+            return ResponseEntity.ok(receivedMessages);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null); // O un mensaje de error más específico
+        }
+    }
+
+    // Endpoint para obtener los mensajes enviados por un usuario
+    /*
+     * Este endpoint permite obtener todos los mensajes que han sido enviados
+     * por un usuario específico, identificado por su ID.
+     *
+     * @param userId El ID del usuario del cual se quieren obtener los mensajes enviados.
+     * @return ResponseEntity con una lista de MessageDTO si el usuario existe,
+     * o un estado NOT_FOUND (404) si el usuario no se encuentra.
+     */
+    @GetMapping("/sent/user/{userId}")
+    public ResponseEntity<List<MessageDTO>> getSentMessagesByUser(@PathVariable Long userId) {
+        try {
+            List<MessageDTO> sentMessages = messageService.getSentByUserId(userId);
+            return ResponseEntity.ok(sentMessages);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null); // O un mensaje de error más específico
         }
     }
 }

--- a/src/main/java/co/edu/udes/backend/controllers/NotificationController.java
+++ b/src/main/java/co/edu/udes/backend/controllers/NotificationController.java
@@ -38,24 +38,22 @@ public class NotificationController {
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@RequestBody List<NotificationDTO> dtos){
-        try{
-            List<Notification> entities = notificationMapper.toEntityList(dtos);
-            return ResponseEntity.ok(notificationService.createMultiple(entities));
-        }catch (Exception e){
-            return ResponseEntity.badRequest().body("Please check the data you are sending" + e.getMessage());
+    public ResponseEntity<NotificationDTO> create(@RequestBody NotificationDTO notificationDTO) {
+        try {
+            NotificationDTO createdNotification = notificationService.create(notificationDTO);
+            return new ResponseEntity<>(createdNotification, HttpStatus.CREATED);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(null); // O un mensaje de error más específico
         }
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<?> update(@PathVariable Long id, @RequestBody NotificationDTO dto) {
-        try{
-            Notification notification = notificationMapper.toEntity(dto);
-            return ResponseEntity.ok(notificationService.update(id, notification));
-        }catch (RuntimeException e){
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-        }catch(Exception e){
-            return ResponseEntity.badRequest().body("Please check the data you are sending");
+    public ResponseEntity<NotificationDTO> update(@PathVariable Long id, @RequestBody NotificationDTO notificationDTO) {
+        try {
+            NotificationDTO updatedNotification = notificationService.update(id, notificationDTO);
+            return ResponseEntity.ok(updatedNotification);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null); // O badRequest si la data es inválida
         }
     }
 
@@ -66,6 +64,27 @@ public class NotificationController {
             return ResponseEntity.noContent().build();
         }catch (RuntimeException e){
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    // modulos
+
+    // Endpoint para obtener las notificaciones recibidas por un usuario
+    /*
+     * Este endpoint permite obtener todas las notificaciones que han sido enviadas
+     * a un usuario específico, identificado por su ID.
+     *
+     * @param userId El ID del usuario del cual se quieren obtener las notificaciones recibidas.
+     * @return ResponseEntity con una lista de NotificationDTO si el usuario existe,
+     * o un estado NOT_FOUND (404) si el usuario no se encuentra.
+     */
+    @GetMapping("/received/user/{userId}")
+    public ResponseEntity<List<NotificationDTO>> getReceivedNotificationsByUser(@PathVariable Long userId) {
+        try {
+            List<NotificationDTO> receivedNotifications = notificationService.getReceivedByUserId(userId);
+            return ResponseEntity.ok(receivedNotifications);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null); // O un mensaje de error más específico
         }
     }
 }

--- a/src/main/java/co/edu/udes/backend/services/MessageService.java
+++ b/src/main/java/co/edu/udes/backend/services/MessageService.java
@@ -3,18 +3,23 @@ package co.edu.udes.backend.services;
 import co.edu.udes.backend.dto.MessageDTO;
 import co.edu.udes.backend.mappers.MessageMapper;
 import co.edu.udes.backend.models.Message;
+import co.edu.udes.backend.models.inheritance.ProfileU;
 import co.edu.udes.backend.repositories.MessageRepository;
+import co.edu.udes.backend.repositories.ProfileURepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class MessageService {
 
     private final MessageRepository messageRepository;
+    private final ProfileURepository profileURepository;
+
     @Autowired
     private MessageMapper messageMapper;
 
@@ -23,10 +28,26 @@ public class MessageService {
         return messageMapper.toDtoList(messages);
     }
 
-    public List<MessageDTO> createMultiple(List<Message> list) {
-        return messageMapper.toDtoList(
-                messageRepository.saveAll(list)
-        );
+    public List<MessageDTO> createMultiple(List<MessageDTO> dtoList) {
+        List<Message> messages = dtoList.stream()
+                .map(dto -> {
+                    Message message = messageMapper.toEntity(dto);
+                    // Asegurar que el remitente exista
+                    ProfileU sender = profileURepository.findById(dto.getSenderId())
+                            .orElseThrow(() -> new RuntimeException("Sender not found with id: " + dto.getSenderId()));
+                    message.setSender(sender);
+                    // Asegurar que los destinatarios existan (el mapper ya los setea por ID)
+                    if (dto.getReceiverIds() != null) {
+                        List<ProfileU> receivers = profileURepository.findAllById(dto.getReceiverIds());
+                        if (receivers.size() != dto.getReceiverIds().size()) {
+                            throw new RuntimeException("One or more receivers not found");
+                        }
+                        // Los receivers se setean a través del mapper en Communication
+                    }
+                    return message;
+                })
+                .collect(Collectors.toList());
+        return messageMapper.toDtoList(messageRepository.saveAll(messages));
     }
 
     public MessageDTO getById(Long id) {
@@ -34,21 +55,88 @@ public class MessageService {
                 .orElseThrow(() -> new RuntimeException("Message not found with id: " + id)));
     }
 
-    public MessageDTO create(Message message) {
+    public MessageDTO create(MessageDTO dto) {
+        Message message = messageMapper.toEntity(dto);
+        // Asegurar que el remitente exista
+        ProfileU sender = profileURepository.findById(dto.getSenderId())
+                .orElseThrow(() -> new RuntimeException("Sender not found with id: " + dto.getSenderId()));
+        message.setSender(sender);
+        // Asegurar que los destinatarios existan
+        if (dto.getReceiverIds() != null) {
+            List<ProfileU> receivers = profileURepository.findAllById(dto.getReceiverIds());
+            if (receivers.size() != dto.getReceiverIds().size()) {
+                throw new RuntimeException("One or more receivers not found");
+            }
+            message.setReceivers(receivers); // Establecer los receivers directamente
+        }
         return messageMapper.toDto(messageRepository.save(message));
-
     }
 
-    public MessageDTO update(Long id, Message message) {
-        messageRepository.findById(id)
+    public MessageDTO update(Long id, MessageDTO dto) {
+        Message existingMessage = messageRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Message not found with id: " + id));
-        message.setId(id);
-        return messageMapper.toDto(messageRepository.save(message));
+        Message updatedMessage = messageMapper.toEntity(dto);
+        updatedMessage.setId(id); // Asegurar que el ID se mantenga
+
+        // Asegurar que el remitente exista
+        ProfileU sender = profileURepository.findById(dto.getSenderId())
+                .orElseThrow(() -> new RuntimeException("Sender not found with id: " + dto.getSenderId()));
+        updatedMessage.setSender(sender);
+
+        // Asegurar que los destinatarios existan
+        if (dto.getReceiverIds() != null) {
+            List<ProfileU> receivers = profileURepository.findAllById(dto.getReceiverIds());
+            if (receivers.size() != dto.getReceiverIds().size()) {
+                throw new RuntimeException("One or more receivers not found");
+            }
+            updatedMessage.setReceivers(receivers); // Establecer los receivers directamente
+        }
+
+        return messageMapper.toDto(messageRepository.save(updatedMessage));
     }
 
     public void delete(Long id) {
         messageRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Message not found with id: " + id));
         messageRepository.deleteById(id);
+    }
+
+    // modulos
+
+    /**
+     * Obtiene todos los mensajes que han sido recibidos por un usuario específico.
+     *
+     * Este método busca un usuario por su ID y luego filtra su lista de comunicaciones
+     * para retornar solo aquellas que son instancias de la entidad Message.
+     * Finalmente, mapea estas entidades Message a una lista de MessageDTO.
+     *
+     * @param userId El ID del usuario del cual se desean obtener los mensajes recibidos.
+     * @return Una lista de MessageDTO que representan los mensajes recibidos por el usuario.
+     * @throws RuntimeException Si no se encuentra un usuario con el ID proporcionado.
+     */
+    public List<MessageDTO> getReceivedByUserId(Long userId) {
+        ProfileU user = profileURepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+        List<Message> receivedMessages = user.getCommunication().stream()
+                .filter(message -> message instanceof Message)
+                .map(message -> (Message) message)
+                .collect(Collectors.toList());
+        return messageMapper.toDtoList(receivedMessages);
+    }
+
+    /**
+     * Obtiene todos los mensajes que han sido enviados por un usuario específico.
+     *
+     * Este método busca un usuario por su ID y luego retorna la lista de mensajes
+     * que tienen a este usuario como remitente, mapeándolos a una lista de MessageDTO.
+     *
+     * @param userId El ID del usuario del cual se desean obtener los mensajes enviados.
+     * @return Una lista de MessageDTO que representan los mensajes enviados por el usuario.
+     * @throws RuntimeException Si no se encuentra un usuario con el ID proporcionado.
+     */
+    public List<MessageDTO> getSentByUserId(Long userId) {
+        ProfileU user = profileURepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+        return messageMapper.toDtoList(user.getMessage());
     }
 }

--- a/src/main/java/co/edu/udes/backend/services/NotificationService.java
+++ b/src/main/java/co/edu/udes/backend/services/NotificationService.java
@@ -3,17 +3,21 @@ package co.edu.udes.backend.services;
 import co.edu.udes.backend.dto.NotificationDTO;
 import co.edu.udes.backend.mappers.NotificationMapper;
 import co.edu.udes.backend.models.Notification;
+import co.edu.udes.backend.models.inheritance.ProfileU;
 import co.edu.udes.backend.repositories.NotificationRepository;
+import co.edu.udes.backend.repositories.ProfileURepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final ProfileURepository profileURepository;
     @Autowired
     private NotificationMapper notificationMapper;
 
@@ -22,10 +26,22 @@ public class NotificationService {
         return notificationMapper.toDtoList(notifications);
     }
 
-    public List<NotificationDTO> createMultiple(List<Notification> list) {
-        return notificationMapper.toDtoList(
-                notificationRepository.saveAll(list)
-        );
+    public List<NotificationDTO> createMultiple(List<NotificationDTO> dtoList) {
+        List<Notification> notifications = dtoList.stream()
+                .map(dto -> {
+                    Notification notification = notificationMapper.toEntity(dto);
+                    // Asegurar que los destinatarios existan
+                    if (dto.getReceiverIds() != null) {
+                        List<ProfileU> receivers = profileURepository.findAllById(dto.getReceiverIds());
+                        if (receivers.size() != dto.getReceiverIds().size()) {
+                            throw new RuntimeException("One or more receivers not found");
+                        }
+                        notification.setReceivers(receivers); // Establecer los receivers directamente
+                    }
+                    return notification;
+                })
+                .collect(Collectors.toList());
+        return notificationMapper.toDtoList(notificationRepository.saveAll(notifications));
     }
 
     public NotificationDTO getById(Long id) {
@@ -33,16 +49,35 @@ public class NotificationService {
                 .orElseThrow(() -> new RuntimeException("Notification not found with id: " + id)));
     }
 
-    public NotificationDTO create(Notification notification) {
+    public NotificationDTO create(NotificationDTO dto) {
+        Notification notification = notificationMapper.toEntity(dto);
+        // Asegurar que los destinatarios existan
+        if (dto.getReceiverIds() != null) {
+            List<ProfileU> receivers = profileURepository.findAllById(dto.getReceiverIds());
+            if (receivers.size() != dto.getReceiverIds().size()) {
+                throw new RuntimeException("One or more receivers not found");
+            }
+            notification.setReceivers(receivers); // Establecer los receivers directamente
+        }
         return notificationMapper.toDto(notificationRepository.save(notification));
-
     }
 
-    public NotificationDTO update(Long id, Notification notification) {
-        notificationRepository.findById(id)
+    public NotificationDTO update(Long id, NotificationDTO dto) {
+        Notification existingNotification = notificationRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Notification not found with id: " + id));
-        notification.setId(id);
-        return notificationMapper.toDto(notificationRepository.save(notification));
+        Notification updatedNotification = notificationMapper.toEntity(dto);
+        updatedNotification.setId(id); // Asegurar que el ID se mantenga
+
+        // Asegurar que los destinatarios existan
+        if (dto.getReceiverIds() != null) {
+            List<ProfileU> receivers = profileURepository.findAllById(dto.getReceiverIds());
+            if (receivers.size() != dto.getReceiverIds().size()) {
+                throw new RuntimeException("One or more receivers not found");
+            }
+            updatedNotification.setReceivers(receivers); // Establecer los receivers directamente
+        }
+
+        return notificationMapper.toDto(notificationRepository.save(updatedNotification));
     }
 
     public void delete(Long id) {
@@ -50,4 +85,28 @@ public class NotificationService {
                 .orElseThrow(() -> new RuntimeException("Notification not found with id: " + id));
         notificationRepository.deleteById(id);
     }
+
+    //modulos
+
+    /**
+     * Obtiene todas las notificaciones recibidas por un usuario específico.
+     *
+     * Este método busca un usuario por su ID y luego filtra su lista de comunicaciones
+     * para retornar solo aquellas que son instancias de la entidad Notification.
+     * Finalmente, mapea estas entidades Notification a una lista de NotificationDTO.
+     *
+     * @param userId El ID del usuario del cual se desean obtener las notificaciones recibidas.
+     * @return Una lista de NotificationDTO que representan las notificaciones recibidas por el usuario.
+     * @throws RuntimeException Si no se encuentra un usuario con el ID proporcionado.
+     */
+    public List<NotificationDTO> getReceivedByUserId(Long userId) {
+        ProfileU user = profileURepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+        List<Notification> receivedNotifications = user.getCommunication().stream()
+                .filter(notification -> notification instanceof Notification)
+                .map(notification -> (Notification) notification)
+                .collect(Collectors.toList());
+        return notificationMapper.toDtoList(receivedNotifications);
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=backend
 
-spring.datasource.url=jdbc:postgresql://129.146.249.153:5434/TestJose
+spring.datasource.url=jdbc:postgresql://129.146.249.153:5434/TestDavid
 spring.datasource.username=root
 spring.datasource.password=UDES2025
 spring.jpa.show-sql=true


### PR DESCRIPTION
This commit introduces the core functionality for internal communication and notifications within the application.

Key changes include:

- Creation of  and  entities inheriting from a common  entity to handle shared attributes like receivers, sent date, content, and read status.
- Implementation of  and  for data transfer.
- Development of  and  using MapStruct for efficient DTO to entity and entity to DTO conversion, including handling of receiver IDs and sender ID.
- Creation of  and  with basic CRUD operations and methods to retrieve messages and notifications for specific users.
- Implementation of  and  to expose REST endpoints for managing messages and notifications, including retrieving by user ID.
- Modification of  entity to include relationships with  and .
- Addition of necessary repositories (, , ).

This module enables users (students, teachers, administrators) to communicate internally and receive automated alerts and reminders for academic events.